### PR TITLE
:bookmark: Bump the version of @kei-g/none to 1.0.8

### DIFF
--- a/none/package.json
+++ b/none/package.json
@@ -13,5 +13,5 @@
   "scripts": {
     "test": ":"
   },
-  "version": "1.0.7"
+  "version": "1.0.8"
 }


### PR DESCRIPTION
This PR bumps the version of @kei-g/none from 1.0.7 to 1.0.8